### PR TITLE
fix(scanner): re-enrich the local node on the peer refresh tick

### DIFF
--- a/services/nvpair-node-scanner/daemon.go
+++ b/services/nvpair-node-scanner/daemon.go
@@ -1467,6 +1467,17 @@ func (d *daemon) refreshPeersLoop(ctx context.Context) {
 			}
 			d.refreshClusterIdentityOnce()
 			d.refreshModelsOnce()
+			// Re-enrich self. onBrowse deliberately skips our own entry (self
+			// is registry-driven), and publishSelf is otherwise only called
+			// when the registry moves -- a service (un)register, an identity
+			// or address change. Nothing else refreshes the local node GPU,
+			// CPU and memory figures, so they stayed frozen at whatever they
+			// were when the daemon started. Observed on an RTX 3060: the card
+			// filled to 9.1 GB while the directory kept reporting the 0.12 GB
+			// it held at startup, with node-info serving the true value every
+			// two seconds the whole time. A peer converges because every
+			// browse event re-enriches it; self had no equivalent path.
+			d.publishSelf()
 		}
 	}
 }


### PR DESCRIPTION
Fixes #4.

`onBrowse` deliberately skips our own entry, so the path that re-enriches every peer on every browse never runs for self. `publishSelf` — the only thing that enriches self — is called at startup, on service (un)register, and after an identity or address change. Nothing was left to converge the local node's GPU, CPU and memory figures, so they stayed at whatever they were when the daemon started.

This calls `publishSelf()` on the `refreshPeersLoop` tick that already refreshes advertised addresses, the mesh, cluster identity and models.

**Verified on hardware**, two paired nodes (Ubuntu + RTX 3060, macOS):

- load a model with GPU offload → `discovery:get-nodes` follows within 20 s, where before it never moved at all
- unload → follows back
- `node-info` and the desktop UI were correct throughout; only the discovery snapshot was frozen

`go vet` and `go test ./...` clean in `services/nvpair-node-scanner`.

One tradeoff worth flagging: `publishSelf` emits `node-updated` unconditionally, so this adds one self update per 15 s tick. The tidier alternative is an `applyInfo` path with a `changed` check, mirroring `applyModels` — happy to switch to that shape if you prefer it.
