### PR TITLE
fix: declare macOS Local Network entitlements for mDNS discovery

### DIFF
--- a/desktop/electron-builder.config.ts
+++ b/desktop/electron-builder.config.ts
@@ -395,7 +395,10 @@ const config: Configuration = {
     mac: {
         executableName: APP_EXECUTABLE_NAME,
         extendInfo: {
-            CFBundleDisplayName: APP_DISPLAY_NAME
+            CFBundleDisplayName: APP_DISPLAY_NAME,
+            NSLocalNetworkUsageDescription:
+                'Personal AI Router uses your local network to discover and connect to paired compute nodes running local inference models.',
+            NSBonjourServices: ['_nvpair-node._tcp']
         },
         icon: './resources/icons/logo.icns',
         // SMAppService (the privileged firewall helper) requires macOS 13+.

--- a/desktop/tests/modular/macos-plist-config.test.ts
+++ b/desktop/tests/modular/macos-plist-config.test.ts
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * electron-builder.config.ts has module-level side effects that throw when
+ * `--mac` / `--win` / `--linux` is not present on the command line, so we
+ * cannot import it directly. Instead we read the source text and verify the
+ * keys structurally — this is sufficient because electron-builder consumes
+ * them from the same literal object.
+ */
+const configSource = readFileSync(
+    resolve(__dirname, '../../electron-builder.config.ts'),
+    'utf-8'
+)
+
+describe('macOS Info.plist configuration', () => {
+    it('declares NSLocalNetworkUsageDescription with a non-empty string', () => {
+        expect(configSource).toContain('NSLocalNetworkUsageDescription')
+
+        // Verify the key is assigned a non-empty string literal (single- or
+        // double-quoted), not just mentioned in a comment.
+        const match = /NSLocalNetworkUsageDescription:\s*\n?\s*['"](.+?)['"]/s.exec(
+            configSource
+        )
+        expect(match).not.toBeNull()
+        expect(match?.[1].length).toBeGreaterThan(0)
+    })
+
+    it('declares NSBonjourServices containing the PAIR node scanner service type', () => {
+        expect(configSource).toContain('NSBonjourServices')
+        expect(configSource).toContain('_nvpair-node._tcp')
+    })
+})


### PR DESCRIPTION
## Problem

On macOS Sequoia (15+), PAIR cannot obtain Local Network permissions. Cross-host mDNS discovery fails with `sendto: no route to host`, and no permission prompt ever appears (issue #3).

Apple's TCC subsystem requires `NSLocalNetworkUsageDescription` and `NSBonjourServices` in the app bundle's `Info.plist`. Without these keys, macOS fails closed — it never displays the consent dialog, the app never appears in *System Settings > Privacy & Security > Local Network*, and all local multicast/unicast sends fail silently.

## Changes

### `desktop/electron-builder.config.ts`
Added two keys to `mac.extendInfo`:
- **`NSLocalNetworkUsageDescription`** — user-facing string shown in the macOS permission prompt
- **`NSBonjourServices`** — declares `_nvpair-node._tcp` as the Bonjour service type the app advertises/browses

### `desktop/tests/modular/macos-plist-config.test.ts` (new)
Unit test verifying both keys are present in the electron-builder config source.

## Verification

| Check | Result |
|---|---|
| `npm run lint` | ✅ Pass |
| `npm run typecheck` | ✅ Pass (node, web, test) |
| `npm run test:unit` | ✅ 2/2 pass |
| `npm run dead-code:check` | ✅ No dead code |
| `node scripts/spdx-headers.mjs` | ✅ 0 missing |

Closes #3