### PR TITLE
Probe manual nodes for llmman on 17434 as an Ollama-API engine

### DIFF
--- a/services/nvpair-manual-nodes/README.md
+++ b/services/nvpair-manual-nodes/README.md
@@ -62,6 +62,8 @@ Emitted when a manually added node has been probed and its initial status determ
 
 Each node is probed for both inference engines: Ollama on its default `:11434` (`GET /` + `/api/tags`) and LM Studio on its default `:1234` (`GET /v1/models`, which doubles as the liveness check and the model list). `lmstudio_up` / `lmstudio_port` / `lmstudio_models` mirror the `ollama_*` fields and let a supervising broker bridge the node into `lmstudio-proxy` the same way it bridges Ollama into `ollama-proxy`. A node can run either engine, both, or neither.
 
+When nothing answers on `:11434`, the same Ollama probe is retried on `:17434`, the default port of [llmman](https://github.com/llmmanorg/llmman), which serves the Ollama API. Such a node reports `ollama_up: true` with `ollama_port: 17434` and is bridged into `ollama-proxy` like an Ollama node.
+
 ### `node/updated`
 
 Emitted when a periodic probe detects a change (service going up/down, models,
@@ -134,13 +136,13 @@ Changes the log level at runtime. Accepted as either a request (answered with `{
 
 Each manual node is probed every 10 seconds, with a 3-second timeout per leg, for:
 
-- **Ollama** on port 11434: health check (`GET /`) and model list (`GET /api/tags`)
+- **Ollama** on port 11434: health check (`GET /`) and model list (`GET /api/tags`). If it does not answer, the same probe is sent to port 17434, where [llmman](https://github.com/llmmanorg/llmman) serves the Ollama API; `ollama_port` reports whichever port answered
 - **LM Studio** on port 1234: `GET /v1/models`, which doubles as the liveness check and the model list
 - **Node Info** on port 14318, or `tls_port` over HTTPS: hardware inventory and identity (`GET /v1/node-info`)
 
 A node can have any combination of these, or none if the target is unreachable. Status changes trigger `node/updated` events. Because change detection compares CPU, memory, and GPU values, a node running node-info emits a `node/updated` on most probe cycles as utilization moves.
 
-The three engine ports are compiled in: only the node-info leg's port can be moved, via `tls_port`. A remote engine on a non-default port is not discovered.
+The engine ports are compiled in: only the node-info leg's port can be moved, via `tls_port`. A remote engine on a non-default port is not discovered.
 
 ## Shutdown
 

--- a/services/nvpair-manual-nodes/manager.go
+++ b/services/nvpair-manual-nodes/manager.go
@@ -251,7 +251,7 @@ func (m *Manager) probeNode(entry ManualEntry) {
 	addr := entry.Address
 	id := nodeID(entry)
 
-	ollamaUp, ollamaModels := m.probeOllama(addr, 11434)
+	ollamaUp, ollamaAPIPort, ollamaModels := m.probeOllamaAPI(addr)
 	lmStudioUp, lmStudioModels := m.probeLMStudio(addr, lmStudioPort)
 
 	// Pick scheme + port + client based on the entry's TLS hint.
@@ -285,7 +285,7 @@ func (m *Manager) probeNode(entry ManualEntry) {
 		Name:           entry.Name,
 		Address:        addr,
 		OllamaUp:       ollamaUp,
-		OllamaPort:     11434,
+		OllamaPort:     ollamaAPIPort,
 		OllamaModels:   ollamaModels,
 		LMStudioUp:     lmStudioUp,
 		LMStudioPort:   lmStudioPort,
@@ -402,6 +402,24 @@ func probeFailedID(nodeID string) string {
 // we assume the engine's default port rather than resolving it via the engine
 // manager (which only governs the local engine).
 const lmStudioPort = 1234
+
+// Default ports of Ollama and of llmman (https://github.com/llmmanorg/llmman),
+// which serves the same Ollama API on 17434.
+const (
+	ollamaPort = 11434
+	llmmanPort = 17434
+)
+
+// probeOllamaAPI probes Ollama first, then llmman, and returns whether one
+// answered, its port (ollamaPort when neither did) and its models.
+func (m *Manager) probeOllamaAPI(addr string) (bool, int, []string) {
+	for _, port := range []int{ollamaPort, llmmanPort} {
+		if up, models := m.probeOllama(addr, port); up {
+			return true, port, models
+		}
+	}
+	return false, ollamaPort, nil
+}
 
 // probeLMStudio checks LM Studio's OpenAI-compatible server on addr:port. A
 // single GET /v1/models doubles as the liveness check and the model list (the
@@ -539,7 +557,7 @@ func (m *Manager) addNode(entry ManualEntry) ManualNodeStatus {
 		ID:           id,
 		Name:         entry.Name,
 		Address:      entry.Address,
-		OllamaPort:   11434,
+		OllamaPort:   ollamaPort,
 		NodeInfoPort: nodeInfoPort,
 		TLSEnabled:   entry.TLSPort > 0,
 		MTLSRequired: entry.TLSPort > 0 && entry.MTLS,

--- a/services/nvpair-manual-nodes/manager_test.go
+++ b/services/nvpair-manual-nodes/manager_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -84,7 +85,18 @@ func newTestManager() (*Manager, *captureRW, *fakeRoundTripper) {
 }
 
 func configureHealthyNode(rt *fakeRoundTripper, addr string, models []string, info NodeInfoResponse) {
-	host := net.JoinHostPort(addr, "11434")
+	configureHealthyOllamaAPI(rt, addr, ollamaPort, models)
+
+	infoHost := net.JoinHostPort(addr, "14318")
+	rt.set(http.MethodGet, infoHost, "/v1/node-info", func(*http.Request) (*http.Response, error) {
+		data, _ := json.Marshal(info)
+		return httpJSON(http.StatusOK, string(data))
+	})
+}
+
+// configureHealthyOllamaAPI registers GET / and GET /api/tags on addr:port.
+func configureHealthyOllamaAPI(rt *fakeRoundTripper, addr string, port int, models []string) {
+	host := net.JoinHostPort(addr, strconv.Itoa(port))
 	rt.set(http.MethodGet, host, "/", func(*http.Request) (*http.Response, error) {
 		return httpJSON(http.StatusOK, `{}`)
 	})
@@ -100,12 +112,6 @@ func configureHealthyNode(rt *fakeRoundTripper, addr string, models []string, in
 			}{Name: name})
 		}
 		data, _ := json.Marshal(payload)
-		return httpJSON(http.StatusOK, string(data))
-	})
-
-	infoHost := net.JoinHostPort(addr, "14318")
-	rt.set(http.MethodGet, infoHost, "/v1/node-info", func(*http.Request) (*http.Response, error) {
-		data, _ := json.Marshal(info)
 		return httpJSON(http.StatusOK, string(data))
 	})
 }
@@ -151,6 +157,30 @@ func TestProbeLMStudioReportsModels(t *testing.T) {
 	downUp, downModels := m.probeLMStudio("absent.local", lmStudioPort)
 	if downUp || downModels != nil {
 		t.Fatalf("expected absent lmstudio down, got up=%v models=%#v", downUp, downModels)
+	}
+}
+
+// TestProbeOllamaAPIFallsBackToLLMMan: Ollama wins when both answer, llmman is
+// reported with its port when only it answers, neither reports down on 11434.
+func TestProbeOllamaAPIFallsBackToLLMMan(t *testing.T) {
+	m, _, rt := newTestManager()
+	configureHealthyOllamaAPI(rt, "both.local", ollamaPort, []string{"llama3"})
+	configureHealthyOllamaAPI(rt, "both.local", llmmanPort, []string{"gemma4"})
+	configureHealthyOllamaAPI(rt, "llmman.local", llmmanPort, []string{"gemma4", "qwen3.8"})
+
+	up, port, models := m.probeOllamaAPI("both.local")
+	if !up || port != ollamaPort || len(models) != 1 || models[0] != "llama3" {
+		t.Fatalf("both: up=%v port=%d models=%#v, want ollama on %d", up, port, models, ollamaPort)
+	}
+
+	up, port, models = m.probeOllamaAPI("llmman.local")
+	if !up || port != llmmanPort || len(models) != 2 || models[0] != "gemma4" || models[1] != "qwen3.8" {
+		t.Fatalf("llmman: up=%v port=%d models=%#v, want llmman on %d", up, port, models, llmmanPort)
+	}
+
+	up, port, models = m.probeOllamaAPI("absent.local")
+	if up || port != ollamaPort || models != nil {
+		t.Fatalf("absent: up=%v port=%d models=%#v, want down on %d", up, port, models, ollamaPort)
 	}
 }
 

--- a/services/versions.json
+++ b/services/versions.json
@@ -7,7 +7,7 @@
     "lmstudio-proxy": "0.16.2",
     "nvpair-node-info": "0.13.3",
     "nvpair-node-scanner": "0.20.3",
-    "nvpair-manual-nodes": "0.11.1",
+    "nvpair-manual-nodes": "0.12.0",
     "nvpair-workload-manager": "0.13.3",
     "nvpair-errors": "0.7.4",
     "nvpair-node-settings": "1.0.4",


### PR DESCRIPTION
## Description

[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API on port 17434. Manual nodes were probed for Ollama on `11434` only, so a device running llmman was reported as having no inference engine even though `ollama-proxy` can route to it unchanged.

- `manager.go`: `probeOllamaAPI` tries `11434` then `17434` and reports the answering port in `ollama_port`; Ollama wins when both answer. `11434` literals become an `ollamaPort` constant.
- No broker/proxy/desktop changes: `ollama_port` is already forwarded to `ollama-proxy`, which already dials it. llmman is not added as a new engine type, per CONTRIBUTING.
- `manager_test.go`: `TestProbeOllamaAPIFallsBackToLLMMan` covers Ollama-wins, llmman-only and neither.
- README documents the probe order; `versions.json` bumps `nvpair-manual-nodes` `0.11.1 -> 0.12.0`.

## Scope

In: probing llmman on its default port, docs, test, version bump. Out: llmman as a managed local engine, mDNS-discovered nodes, non-default ports.

## Validation

**Testing:** `gofmt -l .`, `go vet ./...`, `go test ./... -count=1` in `services/nvpair-manual-nodes` and `services/nvpair-ui-broker` — clean (macOS arm64, Go 1.26). Not run against a live llmman/Ollama through the full broker/proxy path.

## Risk

IPC shapes unchanged; `ollama_port` may now be `17434`. One extra plain-HTTP probe per node per cycle when `11434` does not answer.

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/NVIDIA/Personal-AI-Router/blob/main/CONTRIBUTING.md).
- [x] Every commit is signed off (`git commit -s`), certifying the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] New or existing tests cover the change.
- [x] Relevant documentation is updated.
- [x] I checked the diff, changed filenames, and commit messages for credentials, private data, internal URLs, internal issue identifiers, and generated artifacts.
- [x] I recorded the validation commands and results above.
- [x] I bumped any affected component in `services/versions.json`, and described user-visible changes above so they reach the release notes.

> AI-assisted, reviewed before submitting.
