### PR TITLE
Fix nvpair-tui panic when a table view seeds rows before its first resize

### DIFF
--- a/services/nvpair-tui/ui/cluster.go
+++ b/services/nvpair-tui/ui/cluster.go
@@ -99,6 +99,10 @@ func newClusterView(client *rpc.Client) *clusterView {
 	ti := textinput.New()
 	v := &clusterView{client: client, input: ti}
 	v.table = newTable(nil)
+	// Seed real columns before any RPC result can reach the table: a
+	// zero-column table panics (index out of range) in table.SetRows if
+	// data arrives before the first tea.WindowSizeMsg calls SetSize.
+	v.SetSize(0, 0)
 	return v
 }
 

--- a/services/nvpair-tui/ui/engines.go
+++ b/services/nvpair-tui/ui/engines.go
@@ -72,6 +72,10 @@ func newEnginesView(client *rpc.Client) *enginesView {
 	ti.Placeholder = "model name (e.g. llama3.2)"
 	v := &enginesView{client: client, byName: map[string]engineStatus{}, input: ti}
 	v.table = newTable(nil)
+	// Seed real columns before any RPC result can reach the table: a
+	// zero-column table panics (index out of range) in table.SetRows if
+	// data arrives before the first tea.WindowSizeMsg calls SetSize.
+	v.SetSize(0, 0)
 	return v
 }
 

--- a/services/nvpair-tui/ui/errors.go
+++ b/services/nvpair-tui/ui/errors.go
@@ -47,7 +47,11 @@ var clearKey = key.NewBinding(
 
 func newErrorsView(client *rpc.Client) *errorsView {
 	v := &errorsView{client: client}
-	v.table = newTable(nil)
+	// Seed real columns up front (not nil): errors:get-initial can return
+	// before the first tea.WindowSizeMsg reaches SetSize, and setErrors ->
+	// table.SetRows on a zero-column table panics (index out of range) as
+	// soon as the broker already has >=1 stored error at startup.
+	v.table = newTable(v.columns())
 	return v
 }
 

--- a/services/nvpair-tui/ui/manualnodes.go
+++ b/services/nvpair-tui/ui/manualnodes.go
@@ -67,6 +67,10 @@ func newManualView(client *rpc.Client) *manualView {
 	ti.Placeholder = "host"
 	v := &manualView{client: client, input: ti}
 	v.table = newTable(nil)
+	// Seed real columns before any RPC result can reach the table: a
+	// zero-column table panics (index out of range) in table.SetRows if
+	// data arrives before the first tea.WindowSizeMsg calls SetSize.
+	v.SetSize(0, 0)
 	return v
 }
 

--- a/services/nvpair-tui/ui/nodes.go
+++ b/services/nvpair-tui/ui/nodes.go
@@ -69,6 +69,10 @@ var niInviteKey = key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "invite to
 func newNodesView(client *rpc.Client) *nodesView {
 	v := &nodesView{client: client}
 	v.table = newTable(nil)
+	// Seed real columns before any RPC result can reach setNodes: a
+	// zero-column table panics (index out of range) in table.SetRows if
+	// data arrives before the first tea.WindowSizeMsg calls SetSize.
+	v.SetSize(0, 0)
 	return v
 }
 

--- a/services/nvpair-tui/ui/proxies.go
+++ b/services/nvpair-tui/ui/proxies.go
@@ -94,6 +94,10 @@ func newProxiesView(client *rpc.Client) *proxiesView {
 			{label: "LM Studio", prefix: "lmstudio-proxy", table: newTable(nil)},
 		},
 	}
+	// Seed real columns before any RPC result can reach these tables: a
+	// zero-column table panics (index out of range) in table.SetRows if
+	// data arrives before the first tea.WindowSizeMsg calls SetSize.
+	v.SetSize(0, 0)
 	return v
 }
 

--- a/services/nvpair-tui/ui/workloads.go
+++ b/services/nvpair-tui/ui/workloads.go
@@ -41,6 +41,10 @@ type workloadsSubscribedMsg struct{ err error }
 func newWorkloadsView(client *rpc.Client) *workloadsView {
 	v := &workloadsView{client: client, byKey: map[string]workload{}}
 	v.table = newTable(nil)
+	// Seed real columns before any RPC result can reach the table: a
+	// zero-column table panics (index out of range) in table.SetRows if
+	// data arrives before the first tea.WindowSizeMsg calls SetSize.
+	v.SetSize(0, 0)
 	return v
 }
 

--- a/services/versions.json
+++ b/services/versions.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Single source of truth for all version numbers. See VERSIONING.md for bump rules.",
-  "product": "0.91.7",
-  "installer": "0.91.7",
+  "product": "0.91.8",
+  "installer": "0.91.8",
   "components": {
     "ollama-proxy": "0.26.2",
     "lmstudio-proxy": "0.16.2",
@@ -15,6 +15,6 @@
     "nvpair-engine-manager": "0.17.4",
     "nvpair-cluster-manager": "1.1.4",
     "nvpair-job-scheduler": "0.4.1",
-    "nvpair-tui": "0.7.2"
+    "nvpair-tui": "0.7.3"
   }
 }


### PR DESCRIPTION
This is my first contribution to this repository, so please redirect me if this isn't the right approach.

## Outcome

Fixes a reliable startup crash in `nvpair-tui`. Every table-backed view (`Errors`, `Nodes`, `Cluster`, `Manual`, `Workloads`, `Engines`, `Proxies`) builds its `table.Model` via `newTable(nil)` and only sets real columns inside `SetSize`, which the Bubble Tea runtime calls from the first `tea.WindowSizeMsg`. Each view's `Init()` fires an RPC call (`errors:get-initial`, `nodes:get-initial`, etc.) at the same time, and nothing orders that response against the first `WindowSizeMsg`. When the RPC reply arrives first — which happens reliably whenever the broker already holds at least one stored item at startup (e.g. one prior service error) — the view's `set*()` handler calls `table.SetRows` on a still-zero-column table, and `bubbles/table.renderRow` panics with `index out of range [0] with length 0`, killing the whole TUI.

Fix: seed each table with real columns at construction time instead of `nil`, so `SetRows` never sees zero columns regardless of message ordering.

- `ui/errors.go`: build via `v.columns()` instead of `nil` (it already computes columns from `v.width`, clamped for a zero width).
- `ui/nodes.go`, `ui/cluster.go`, `ui/manualnodes.go`, `ui/workloads.go`, `ui/engines.go`, `ui/proxies.go`: call `v.SetSize(0, 0)` right after construction, running the same `SetColumns` each view's own `SetSize` already performs on a real resize.

Bumped `nvpair-tui` 0.7.2 -> 0.7.3 (PATCH: bug fix, no IPC/HTTP change) and `product`/`installer` 0.91.7 -> 0.91.8 accordingly.

## In scope / out of scope

In scope: the seven `newTable(nil)` sites in `nvpair-tui/ui`. Out of scope: any broader change to how views are sized or how the broker reports errors.

## Validation environment

Linux x86_64, Go 1.25.0.

```
cd services/nvpair-tui && go build ./... && go vet ./... && go test ./...   # all pass
node scripts/spdx-headers.mjs                                              # 871 checked, 0 missing
cd services/tests && go test ./...
```

The cross-process suite has 7 pre-existing failures (`TestBrokerRestoresClusterIdentityAfterRestart`, `TestLogSetLevelViaRPC`, `TestLogLevelEnvFallback`, `TestWorkloadManagerInboundRelay`, `TestWorkloadOutOfOrderSuppressed`, `TestWorkloadFailedOnNodeLoss`, `TestWorkloadManagerOutboundBroadcast`). I confirmed these reproduce identically on `main` without this change, so they're unrelated to this fix.

Manually reproduced the panic against the published 0.1.1 `.deb` (a real broker with a stored service error present crashes the stock `nvpair-tui` on every launch), then confirmed a `nvpair-tui` built with this patch starts cleanly against the same broker and on-disk state.

## Compatibility and security risk

None expected — this only changes when a table's columns are initialized, not any wire format, IPC contract, or stored data.

## Documentation

No user-facing behavior changes beyond "it no longer crashes," so no docs changes.