### PR TITLE
Expose observed loaded-model VRAM telemetry

### DIFF
--- a/services/nvpair-engine-manager/manifests/ollama.json
+++ b/services/nvpair-engine-manager/manifests/ollama.json
@@ -88,10 +88,10 @@
       "http": { "method": "GET", "path": "/api/tags" },
       "result": { "array": "models", "field": "name" }
     },
-    "loaded_models": {
-      "description": "List models currently loaded in memory (every /api/ps entry is resident).",
-      "http": { "method": "GET", "path": "/api/ps" },
-      "result": { "array": "models", "field": "name" }
+      "loaded_models": {
+        "description": "List models currently loaded in memory (every /api/ps entry is resident).",
+        "http": { "method": "GET", "path": "/api/ps" },
+        "result": { "array": "models", "field": "name", "vram_field": "size_vram" }
     },
     "pull_model": {
       "description": "Pull a model by name (params: {\"name\": \"<model>\"}).",

--- a/services/nvpair-engine-manager/model_vram.go
+++ b/services/nvpair-engine-manager/model_vram.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// extractLoadedVRAM uses the manifest's loaded-model row filter and name field.
+// A bad optional metric must not discard the otherwise usable model inventory.
+func extractLoadedVRAM(raw json.RawMessage, spec *ActionResult) map[string]uint64 {
+	if spec == nil || spec.VRAMField == "" {
+		return nil
+	}
+	var body map[string]json.RawMessage
+	if json.Unmarshal(raw, &body) != nil {
+		return nil
+	}
+	var rows []map[string]json.RawMessage
+	if json.Unmarshal(body[spec.Array], &rows) != nil {
+		return nil
+	}
+	var result map[string]uint64
+	for _, row := range rows {
+		if spec.Match != nil && !matchRow(row, spec.Match) {
+			continue
+		}
+		var name string
+		if json.Unmarshal(row[spec.Field], &name) != nil || name == "" {
+			continue
+		}
+		value := bytes.TrimSpace(row[spec.VRAMField])
+		var size uint64
+		if len(value) == 0 || bytes.Equal(value, []byte("null")) || json.Unmarshal(value, &size) != nil {
+			continue
+		}
+		if result == nil {
+			result = make(map[string]uint64)
+		}
+		result[name] = size
+	}
+	return result
+}

--- a/services/nvpair-engine-manager/models.go
+++ b/services/nvpair-engine-manager/models.go
@@ -42,6 +42,9 @@ type ModelsResult struct {
 	Models         []string            `json:"models"`
 	ByEngine       map[string][]string `json:"modelsByEngine,omitempty"`
 	LoadedByEngine map[string][]string `json:"loadedByEngine,omitempty"`
+	// LoadedVRAMByEngine contains observed GPU-resident bytes, not required
+	// capacity. Missing model keys are unknown; an explicit zero is preserved.
+	LoadedVRAMByEngine map[string]map[string]uint64 `json:"loadedVramByEngine,omitempty"`
 }
 
 // Models returns the union of model names served by every installed, running
@@ -79,6 +82,7 @@ func (e *Executor) ModelsResult(ctx context.Context) ModelsResult {
 	listOK := make([]bool, len(engineNames))
 	loaded := make([][]string, len(engineNames))
 	loadedOK := make([]bool, len(engineNames))
+	loadedVRAM := make([]map[string]uint64, len(engineNames))
 	var wg sync.WaitGroup
 	for i, name := range engineNames {
 		mf, ok := e.reg.Get(name)
@@ -121,6 +125,7 @@ func (e *Executor) ModelsResult(ctx context.Context) ModelsResult {
 					// "unknown". An action or shape error leaves loadedOK[i] false.
 					loaded[i] = models
 					loadedOK[i] = true
+					loadedVRAM[i] = extractLoadedVRAM(raw, loadedSpec)
 				} else {
 					slog.Debug("engine:models loaded_models returned an invalid inventory", "engine", name)
 				}
@@ -160,6 +165,12 @@ func (e *Executor) ModelsResult(ctx context.Context) ModelsResult {
 				ld = []string{}
 			}
 			res.LoadedByEngine[engineNames[i]] = ld
+			if len(loadedVRAM[i]) > 0 {
+				if res.LoadedVRAMByEngine == nil {
+					res.LoadedVRAMByEngine = make(map[string]map[string]uint64)
+				}
+				res.LoadedVRAMByEngine[engineNames[i]] = loadedVRAM[i]
+			}
 		}
 	}
 	return res

--- a/services/nvpair-engine-manager/registry.go
+++ b/services/nvpair-engine-manager/registry.go
@@ -189,6 +189,9 @@ type Action struct {
 type ActionResult struct {
 	Array string `json:"array"` // top-level array field, e.g. "models" / "data"
 	Field string `json:"field"` // string field per element, e.g. "name" / "id"
+	// VRAMField is an optional unsigned byte count on a loaded_models row.
+	// It describes observed GPU residency, never a minimum memory requirement.
+	VRAMField string `json:"vram_field,omitempty"`
 	// Match, when set, keeps only array elements that pass the ResultMatch
 	// filter. It lets loaded_models reuse the same extractor as list_models
 	// across engines whose list endpoint tags residency (LM Studio's

--- a/services/nvpair-node-scanner/connreuse_test.go
+++ b/services/nvpair-node-scanner/connreuse_test.go
@@ -74,7 +74,7 @@ func TestModelsClient_ReusesPeerConnections(t *testing.T) {
 	// pinned mTLS path instead of the plaintext self-fetch.
 	const rounds = 5
 	for i := 0; i < rounds; i++ {
-		models, _, _, ok := d.fetchModels("localhost", port, "uuid-peer")
+		models, _, _, _, ok := d.fetchModels("localhost", port, "uuid-peer")
 		if !ok || len(models) != 1 || models[0] != "m" {
 			t.Fatalf("round %d: ok=%v models=%v", i, ok, models)
 		}

--- a/services/nvpair-node-scanner/daemon.go
+++ b/services/nvpair-node-scanner/daemon.go
@@ -109,6 +109,8 @@ type daemon struct {
 	// same /v1/models fetch, so a transient miss reuses it rather than blanking
 	// a remote node's loaded state. Keyed by hostUuid.
 	lastLoadedByEngine map[string]map[string][]string
+	// Last-successful model VRAM observations, following the inventory cache lifecycle.
+	lastLoadedVRAMByEngine map[string]map[string]map[string]uint64
 	// nodeInfoDown holds the nodes whose last node-info enrichment failed, so
 	// the outage is reported when it starts and when it ends rather than once
 	// per sweep. Guarded by infoMu with the caches it explains: the reason a
@@ -832,6 +834,10 @@ func (d *daemon) dropSelf(oldHostUUID, newHostUUID string) {
 	delete(d.lastModels, oldHostUUID)
 	delete(d.lastModelsByEngine, oldHostUUID)
 	delete(d.lastLoadedByEngine, oldHostUUID)
+	if value, ok := d.lastLoadedVRAMByEngine[oldHostUUID]; ok {
+		d.lastLoadedVRAMByEngine[newHostUUID] = value
+		delete(d.lastLoadedVRAMByEngine, oldHostUUID)
+	}
 	d.infoMu.Unlock()
 	if existed {
 		d.emit(noderec.NotifyNodeRemoved, noderec.DirectoryNode{HostUUID: oldHostUUID, Name: node.Name})
@@ -1334,11 +1340,11 @@ func (d *daemon) enrichModelsCandidates(node *noderec.DirectoryNode, hosts []str
 		return
 	}
 	ask := func(host string) (modelInventory, bool) {
-		models, byEngine, loadedByEngine, fetched := d.fetchModels(host, em.Port, node.ClusterUUID)
+		models, byEngine, loadedByEngine, loadedVRAMByEngine, fetched := d.fetchModels(host, em.Port, node.ClusterUUID)
 		if !fetched {
 			return modelInventory{}, false
 		}
-		return modelInventory{models: models, byEngine: byEngine, loadedByEngine: loadedByEngine}, true
+		return modelInventory{models: models, byEngine: byEngine, loadedByEngine: loadedByEngine, loadedVRAMByEngine: loadedVRAMByEngine}, true
 	}
 	key := hostKey{hostUUID: node.HostUUID, service: noderec.ServiceEngineManager}
 	if _, inventory, ok := askRemembered(&d.enrichHosts, key, hosts, ask); ok {
@@ -1355,21 +1361,28 @@ func (d *daemon) enrichModelsCandidates(node *noderec.DirectoryNode, hosts []str
 		d.lastModels[node.HostUUID] = inventory.models
 		d.lastModelsByEngine[node.HostUUID] = inventory.byEngine
 		d.lastLoadedByEngine[node.HostUUID] = inventory.loadedByEngine
+		if d.lastLoadedVRAMByEngine == nil {
+			d.lastLoadedVRAMByEngine = make(map[string]map[string]map[string]uint64)
+		}
+		d.lastLoadedVRAMByEngine[node.HostUUID] = inventory.loadedVRAMByEngine
 		d.infoMu.Unlock()
 		node.Models = inventory.models
 		node.ModelsByEngine = inventory.byEngine
 		node.LoadedByEngine = inventory.loadedByEngine
+		node.LoadedVRAMByEngine = inventory.loadedVRAMByEngine
 		return
 	}
 	d.infoMu.Lock()
 	cached, had := d.lastModels[node.HostUUID]
 	cachedByEngine := d.lastModelsByEngine[node.HostUUID]
 	cachedLoaded := d.lastLoadedByEngine[node.HostUUID]
+	cachedVRAM := d.lastLoadedVRAMByEngine[node.HostUUID]
 	d.infoMu.Unlock()
 	if had {
 		node.Models = cached
 		node.ModelsByEngine = cachedByEngine
 		node.LoadedByEngine = cachedLoaded
+		node.LoadedVRAMByEngine = cachedVRAM
 	}
 }
 
@@ -1387,32 +1400,33 @@ func (d *daemon) enrichModelsCandidates(node *noderec.DirectoryNode, hosts []str
 // dialed over loopback (both callers force that for self), which stays plain and
 // therefore keeps working when this node belongs to no cluster — a standalone
 // machine still has to show its own models.
-func (d *daemon) fetchModels(ip string, port int, clusterUUID string) ([]string, map[string][]string, map[string][]string, bool) {
+func (d *daemon) fetchModels(ip string, port int, clusterUUID string) ([]string, map[string][]string, map[string][]string, map[string]map[string]uint64, bool) {
 	client, scheme, ok := d.modelsClient(ip, clusterUUID)
 	if !ok {
 		slog.Debug("model enrichment skipped: peer is not a pinned cluster member",
 			"ip", ip, "clusterUuid", clusterUUID)
-		return nil, nil, nil, false
+		return nil, nil, nil, nil, false
 	}
 	url := scheme + "://" + net.JoinHostPort(ip, strconv.Itoa(port)) + "/v1/models"
 	resp, err := client.Get(url)
 	if err != nil {
 		slog.Debug("model enrichment failed", "ip", ip, "url", url, "err", err)
-		return nil, nil, nil, false
+		return nil, nil, nil, nil, false
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, nil, nil, false
+		return nil, nil, nil, nil, false
 	}
 	var body struct {
-		Models         []string            `json:"models"`
-		ModelsByEngine map[string][]string `json:"modelsByEngine"`
-		LoadedByEngine map[string][]string `json:"loadedByEngine"`
+		Models             []string                     `json:"models"`
+		ModelsByEngine     map[string][]string          `json:"modelsByEngine"`
+		LoadedByEngine     map[string][]string          `json:"loadedByEngine"`
+		LoadedVRAMByEngine map[string]map[string]uint64 `json:"loadedVramByEngine"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		return nil, nil, nil, false
+		return nil, nil, nil, nil, false
 	}
-	return body.Models, body.ModelsByEngine, body.LoadedByEngine, true
+	return body.Models, body.ModelsByEngine, body.LoadedByEngine, body.LoadedVRAMByEngine, true
 }
 
 // modelsClient picks the transport for a model fetch: the plain client over
@@ -1809,11 +1823,11 @@ func (d *daemon) refreshNodeModelsCandidates(hostUUID, guardIP string, hosts []s
 		hosts = []string{loopbackHost}
 	}
 	ask := func(host string) (modelInventory, bool) {
-		models, byEngine, loadedByEngine, fetched := d.fetchModels(host, emPort, clusterUUID)
+		models, byEngine, loadedByEngine, loadedVRAMByEngine, fetched := d.fetchModels(host, emPort, clusterUUID)
 		if !fetched {
 			return modelInventory{}, false
 		}
-		return modelInventory{models: models, byEngine: byEngine, loadedByEngine: loadedByEngine}, true
+		return modelInventory{models: models, byEngine: byEngine, loadedByEngine: loadedByEngine, loadedVRAMByEngine: loadedVRAMByEngine}, true
 	}
 	key := hostKey{hostUUID: hostUUID, service: noderec.ServiceEngineManager}
 	_, inventory, fetched := askRemembered(&d.enrichHosts, key, hosts, ask)
@@ -1842,9 +1856,13 @@ func (d *daemon) refreshNodeModelsCandidates(hostUUID, guardIP string, hosts []s
 	d.lastModels[hostUUID] = models
 	d.lastModelsByEngine[hostUUID] = byEngine
 	d.lastLoadedByEngine[hostUUID] = loadedByEngine
+	if d.lastLoadedVRAMByEngine == nil {
+		d.lastLoadedVRAMByEngine = make(map[string]map[string]map[string]uint64)
+	}
+	d.lastLoadedVRAMByEngine[hostUUID] = inventory.loadedVRAMByEngine
 	d.infoMu.Unlock()
 
-	node, changed, valid := d.dir.applyModels(hostUUID, guardIP, emPort, models, byEngine, loadedByEngine)
+	node, changed, valid := d.dir.applyModels(hostUUID, guardIP, emPort, models, byEngine, loadedByEngine, inventory.loadedVRAMByEngine)
 	if !valid {
 		return false
 	}
@@ -1864,6 +1882,7 @@ func (d *daemon) forget(hostUUID string) {
 	delete(d.lastModels, hostUUID)
 	delete(d.lastModelsByEngine, hostUUID)
 	delete(d.lastLoadedByEngine, hostUUID)
+	delete(d.lastLoadedVRAMByEngine, hostUUID)
 	delete(d.nodeInfoDown, hostUUID)
 	d.infoMu.Unlock()
 	d.activityMu.Lock()

--- a/services/nvpair-node-scanner/directory.go
+++ b/services/nvpair-node-scanner/directory.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"log/slog"
+	"maps"
 	"sort"
 	"sync"
 	"time"
@@ -241,7 +242,7 @@ func (d *directory) snapshot(filter noderec.ServiceKey) []noderec.DirectoryNode 
 // Returns the (possibly updated) node, whether the inventory changed, and
 // whether the guarded apply was valid. ok == false means the result is stale
 // (node gone or re-addressed) and the caller must not cache or emit it.
-func (d *directory) applyModels(hostUUID, ip string, emPort int, models []string, byEngine, loadedByEngine map[string][]string) (node noderec.DirectoryNode, changed, ok bool) {
+func (d *directory) applyModels(hostUUID, ip string, emPort int, models []string, byEngine, loadedByEngine map[string][]string, loadedVRAMByEngine map[string]map[string]uint64) (node noderec.DirectoryNode, changed, ok bool) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	n, present := d.nodes[hostUUID]
@@ -252,12 +253,13 @@ func (d *directory) applyModels(hostUUID, ip string, emPort int, models []string
 	if !has || n.IP != ip || em.Port != emPort {
 		return n, false, false
 	}
-	if sameStringSet(n.Models, models) && sameByEngine(n.ModelsByEngine, byEngine) && sameByEngine(n.LoadedByEngine, loadedByEngine) {
+	if sameStringSet(n.Models, models) && sameByEngine(n.ModelsByEngine, byEngine) && sameByEngine(n.LoadedByEngine, loadedByEngine) && maps.EqualFunc(n.LoadedVRAMByEngine, loadedVRAMByEngine, maps.Equal[map[string]uint64, map[string]uint64]) {
 		return n, false, true
 	}
 	n.Models = models
 	n.ModelsByEngine = byEngine
 	n.LoadedByEngine = loadedByEngine
+	n.LoadedVRAMByEngine = loadedVRAMByEngine
 	d.nodes[hostUUID] = n
 	return n, true, true
 }

--- a/services/nvpair-node-scanner/enrich_hosts.go
+++ b/services/nvpair-node-scanner/enrich_hosts.go
@@ -13,9 +13,10 @@ import (
 // modelInventory is the three-part answer a node's engine manager gives, carried
 // as one value so the concurrent ask can return it.
 type modelInventory struct {
-	models         []string
-	byEngine       map[string][]string
-	loadedByEngine map[string][]string
+	models             []string
+	byEngine           map[string][]string
+	loadedByEngine     map[string][]string
+	loadedVRAMByEngine map[string]map[string]uint64
 }
 
 // hostKey identifies one node's endpoint for one service. Node-info and the engine

--- a/services/nvpair-node-scanner/refresh_test.go
+++ b/services/nvpair-node-scanner/refresh_test.go
@@ -445,7 +445,7 @@ func TestApplyModelsGuard(t *testing.T) {
 	d := newDirectory()
 
 	// Removed mid-sweep: node absent -> not resurrected.
-	if _, changed, ok := d.applyModels("ghost", "127.0.0.1", 14322, []string{"a"}, nil, nil); ok || changed {
+	if _, changed, ok := d.applyModels("ghost", "127.0.0.1", 14322, []string{"a"}, nil, nil, nil); ok || changed {
 		t.Errorf("applyModels on an absent node = (changed %v, ok %v), want (false, false)", changed, ok)
 	}
 	if _, present := d.get("ghost"); present {
@@ -459,11 +459,11 @@ func TestApplyModelsGuard(t *testing.T) {
 		Services: map[noderec.ServiceKey]noderec.ServiceStatus{noderec.ServiceEngineManager: {Port: 14322}},
 		Models:   []string{"old"},
 	})
-	if _, changed, ok := d.applyModels("peer-E", "127.0.0.1", 14322, []string{"new"}, nil, nil); ok || changed {
+	if _, changed, ok := d.applyModels("peer-E", "127.0.0.1", 14322, []string{"new"}, nil, nil, nil); ok || changed {
 		t.Errorf("applyModels with a stale IP = (changed %v, ok %v), want (false, false)", changed, ok)
 	}
 	// em port changed -> also discarded.
-	if _, changed, ok := d.applyModels("peer-E", "10.0.0.9", 99999, []string{"new"}, nil, nil); ok || changed {
+	if _, changed, ok := d.applyModels("peer-E", "10.0.0.9", 99999, []string{"new"}, nil, nil, nil); ok || changed {
 		t.Errorf("applyModels with a stale em port = (changed %v, ok %v), want (false, false)", changed, ok)
 	}
 	got, _ := d.get("peer-E")

--- a/services/nvpair-ui-broker/broker.go
+++ b/services/nvpair-ui-broker/broker.go
@@ -112,6 +112,9 @@ type AvailableNode struct {
 	// consumer show which of a remote node's models are loaded. Omitted
 	// when no engine reports loaded state.
 	LoadedByEngine map[string][]string `json:"loadedByEngine,omitempty"`
+	// LoadedVRAMByEngine reports last-observed GPU-resident bytes per engine/model.
+	// It is not a minimum requirement or an admission signal. Zero is known; absent is unknown.
+	LoadedVRAMByEngine map[string]map[string]uint64 `json:"loadedVramByEngine,omitempty"`
 }
 
 // GetNodesResult is the response to "discovery:get-nodes". Wrapped in an

--- a/services/nvpair-ui-broker/discovery.go
+++ b/services/nvpair-ui-broker/discovery.go
@@ -71,6 +71,9 @@ type EnrichedNode struct {
 	// peer's engine-manager /v1/models loadedByEngine field. Carried through to
 	// AvailableNode so a remote node's cards can reflect loaded state.
 	LoadedByEngine map[string][]string `json:"loadedByEngine,omitempty"`
+	// LoadedVRAMByEngine reports last-observed GPU-resident bytes per engine/model.
+	// It is not a minimum requirement or an admission signal. Zero is known; absent is unknown.
+	LoadedVRAMByEngine map[string]map[string]uint64 `json:"loadedVramByEngine,omitempty"`
 }
 
 // directoryToEnriched projects the promoted daemon's DirectoryNode onto the
@@ -95,20 +98,21 @@ func directoryToEnriched(n noderec.DirectoryNode) EnrichedNode {
 		port = ni.Port
 	}
 	return EnrichedNode{
-		ID:             n.Name,
-		HostUUID:       n.HostUUID,
-		Host:           n.Name,
-		Port:           port,
-		Addresses:      addrs,
-		TXT:            txt,
-		GPUs:           n.GPUs,
-		CPU:            n.CPU,
-		Memory:         n.Memory,
-		Trusted:        n.Trusted,
-		Clustered:      n.Clustered(),
-		Models:         n.Models,
-		ModelsByEngine: n.ModelsByEngine,
-		LoadedByEngine: n.LoadedByEngine,
+		ID:                 n.Name,
+		HostUUID:           n.HostUUID,
+		Host:               n.Name,
+		Port:               port,
+		Addresses:          addrs,
+		TXT:                txt,
+		GPUs:               n.GPUs,
+		CPU:                n.CPU,
+		Memory:             n.Memory,
+		Trusted:            n.Trusted,
+		Clustered:          n.Clustered(),
+		Models:             n.Models,
+		ModelsByEngine:     n.ModelsByEngine,
+		LoadedByEngine:     n.LoadedByEngine,
+		LoadedVRAMByEngine: n.LoadedVRAMByEngine,
 	}
 }
 
@@ -311,18 +315,19 @@ func (sn storedNode) toAvailable() AvailableNode {
 		candidates = nil
 	}
 	return AvailableNode{
-		ID:             n.ID,
-		Name:           n.ID,
-		HostUUID:       n.HostUUID,
-		IPAddress:      primary,
-		IPAddresses:    candidates,
-		Port:           n.Port,
-		LastSeen:       sn.lastSeen.Unix(),
-		Trusted:        n.Trusted,
-		Clustered:      n.Clustered,
-		Models:         n.Models,
-		ModelsByEngine: n.ModelsByEngine,
-		LoadedByEngine: n.LoadedByEngine,
+		ID:                 n.ID,
+		Name:               n.ID,
+		HostUUID:           n.HostUUID,
+		IPAddress:          primary,
+		IPAddresses:        candidates,
+		Port:               n.Port,
+		LastSeen:           sn.lastSeen.Unix(),
+		Trusted:            n.Trusted,
+		Clustered:          n.Clustered,
+		Models:             n.Models,
+		ModelsByEngine:     n.ModelsByEngine,
+		LoadedByEngine:     n.LoadedByEngine,
+		LoadedVRAMByEngine: n.LoadedVRAMByEngine,
 	}
 }
 

--- a/services/shared/noderec/noderec.go
+++ b/services/shared/noderec/noderec.go
@@ -514,7 +514,10 @@ type DirectoryNode struct {
 	// empty list means "running, nothing loaded"; a missing key means the peer
 	// didn't report loaded state for it. Omitted when the peer reports none.
 	LoadedByEngine map[string][]string `json:"loadedByEngine,omitempty"`
-	LastSeen       int64               `json:"lastSeen"` // Unix seconds
+	// LoadedVRAMByEngine reports last-observed GPU-resident bytes per engine/model.
+	// It is not a minimum requirement or an admission signal. Zero is known; absent is unknown.
+	LoadedVRAMByEngine map[string]map[string]uint64 `json:"loadedVramByEngine,omitempty"`
+	LastSeen           int64                        `json:"lastSeen"` // Unix seconds
 }
 
 // Clustered reports whether the node advertises a cluster identity.


### PR DESCRIPTION
## Summary
- expose observed loaded-model GPU-resident bytes from the engine manager
- propagate telemetry through node scanning and UI broker discovery payloads
- preserve unknown versus known-zero values and document that this is telemetry, not a routing admission requirement

Related to #7. This PR intentionally does not reject or rank nodes based on size_vram; that field is observed residency and can represent CPU/GPU offload.

## Validation
- go test ./... in services/nvpair-engine-manager
- go test ./... in services/nvpair-node-scanner
- go test ./... in services/nvpair-ui-broker
- go test ./... in services/shared