### PR TITLE
netpick: recognise Kubernetes CNI interfaces as virtual so a node publishes its uplink

### DIFF
--- a/services/shared/netpick/local.go
+++ b/services/shared/netpick/local.go
@@ -70,9 +70,20 @@ func (e Evidence) peerOnLink(iface string) bool { return e.PeerOnLink[iface] }
 func (e Evidence) peerObserved(ip string) bool  { return e.PeerObserved[ip] }
 
 // virtualIface reports whether an interface name looks like a virtual / overlay
-// adapter (Docker, Hyper-V vEthernet, VPN/tunnel, VM host-only, WSL). Such an
-// address is almost never how a LAN peer reaches this host, so rankLocal ranks
-// every qualified physical address ahead of all of them.
+// adapter (Docker, Hyper-V vEthernet, VPN/tunnel, VM host-only, WSL, Kubernetes
+// CNI). Such an address is almost never how a LAN peer reaches this host, so
+// rankLocal ranks every qualified physical address ahead of all of them.
+//
+// Kubernetes hosts need the overlay pass to be complete rather than merely the
+// physical pass to be right. On an OVN-Kubernetes node the physical NIC carries
+// no address at all: the LAN address sits on the OVS uplink bridge "br-ex",
+// which the "br-" rule already demotes, while the pod-network management port
+// "ovn-k8s-mp0" holds a routable-looking /23 that nothing off the node can
+// reach. If that port counts as physical it is the only physical candidate,
+// qualifies, and is published as canonical -- the Docker-bridge failure again,
+// with an address every peer is told to dial and none can. Naming the CNI
+// interfaces virtual sends both to the overlay pass, where the default-route
+// evidence picks the uplink.
 //
 // It is a demotion and not an exclusion because on some hosts it is the only
 // answer there is: a Windows host on a Hyper-V external switch holds its LAN
@@ -94,6 +105,10 @@ func virtualIface(name string) bool {
 		"veth", "docker", "br-", "vethernet", "vmnet", "vboxnet", "virbr",
 		"tailscale", "zt", "utun", "wg", "tun", "tap", "ppp", "vpn",
 		"hyper-v", "virtual", "wsl", "loopback", "isatap", "teredo",
+		// Kubernetes CNI: OVN-Kubernetes / Open vSwitch, Geneve and VXLAN
+		// tunnel endpoints, flannel, Calico, Cilium, Antrea, kube-proxy IPVS.
+		"ovn-", "ovs-", "genev", "vxlan", "flannel", "cni", "cali", "cilium",
+		"antrea", "kube",
 	} {
 		if strings.Contains(n, v) {
 			return true

--- a/services/shared/netpick/netpick_test.go
+++ b/services/shared/netpick/netpick_test.go
@@ -156,7 +156,8 @@ func TestCandidates_Deduplicates(t *testing.T) {
 }
 
 func TestVirtualIface(t *testing.T) {
-	for _, n := range []string{"vEthernet (Default Switch)", "docker0", "br-1a2b", "tailscale0", "utun3", "VirtualBox Host-Only", "vEthernet (WSL)"} {
+	for _, n := range []string{"vEthernet (Default Switch)", "docker0", "br-1a2b", "tailscale0", "utun3", "VirtualBox Host-Only", "vEthernet (WSL)",
+		"ovn-k8s-mp0", "ovs-system", "genev_sys_6081", "vxlan.calico", "flannel.1", "cni0", "cali1a2b3c4d5e6", "cilium_host", "antrea-gw0", "kube-ipvs0"} {
 		if !virtualIface(n) {
 			t.Errorf("virtualIface(%q) = false, want true", n)
 		}
@@ -220,6 +221,49 @@ func TestRankLocal_ExcludesVirtual(t *testing.T) {
 		if ip == "172.17.0.1" || ip == "172.18.0.1" {
 			t.Errorf("rankLocal published container bridge %s", ip)
 		}
+	}
+}
+
+// ovnKubernetesHost describes a Kubernetes node running OVN-Kubernetes, the
+// OpenShift default. The physical NIC is enslaved to the OVS uplink bridge and
+// holds no address; the LAN address lives on "br-ex", and the pod network's
+// management port "ovn-k8s-mp0" holds a /23 that no machine off the node can
+// reach. The default route leaves through br-ex.
+func ovnKubernetesHost() []localIface {
+	return []localIface{
+		{name: "eno1"},
+		{name: "br-ex", addrs: []localAddr{{ip: "192.168.1.100", prefixLen: 24}}},
+		{name: "br-int"},
+		{name: "ovs-system"},
+		{name: "genev_sys_6081"},
+		{name: "ovn-k8s-mp0", addrs: []localAddr{{ip: "10.128.0.2", prefixLen: 23}}},
+	}
+}
+
+// TestRankLocal_OVNKubernetesPublishesTheUplink is the reported defect. "br-ex"
+// was demoted by the "br-" rule while "ovn-k8s-mp0" counted as physical, so the
+// node published its pod-network address as canonical and every peer was told
+// to dial an address it could not reach. Both belong to the overlay pass, where
+// the default-route evidence picks the uplink.
+func TestRankLocal_OVNKubernetesPublishesTheUplink(t *testing.T) {
+	got := rankLocal(ovnKubernetesHost(), Evidence{}, "192.168.1.100")
+	if len(got) == 0 {
+		t.Fatal("rankLocal returned no candidates")
+	}
+	if got[0] != "192.168.1.100" {
+		t.Fatalf("canonical address = %q, want 192.168.1.100 (the uplink bridge, not the pod network); full order %v", got[0], got)
+	}
+}
+
+// TestRankLocal_OVNKubernetesPeerOnLinkWinsWithoutRoute: the route source is
+// one signal, and a host can fail to report it. A peer inside the uplink's own
+// subnet is stronger evidence, and it alone must be enough to keep the
+// pod-network address off the front of the list.
+func TestRankLocal_OVNKubernetesPeerOnLinkWinsWithoutRoute(t *testing.T) {
+	ev := Evidence{PeerOnLink: map[string]bool{"br-ex": true}}
+	got := rankLocal(ovnKubernetesHost(), ev, "")
+	if len(got) == 0 || got[0] != "192.168.1.100" {
+		t.Fatalf("canonical address = %v, want 192.168.1.100 first", got)
 	}
 }
 

--- a/services/versions.json
+++ b/services/versions.json
@@ -1,12 +1,12 @@
 {
   "$comment": "Single source of truth for all version numbers. See VERSIONING.md for bump rules.",
-  "product": "0.91.7",
-  "installer": "0.91.7",
+  "product": "0.91.8",
+  "installer": "0.91.8",
   "components": {
     "ollama-proxy": "0.26.2",
     "lmstudio-proxy": "0.16.2",
     "nvpair-node-info": "0.13.3",
-    "nvpair-node-scanner": "0.20.3",
+    "nvpair-node-scanner": "0.20.4",
     "nvpair-manual-nodes": "0.11.1",
     "nvpair-workload-manager": "0.13.3",
     "nvpair-errors": "0.7.4",


### PR DESCRIPTION
## Description

On an OVN-Kubernetes host (the OpenShift default) a PAIR node advertises its pod-network address instead of its LAN address, so peers discover a node they cannot reach.

The physical NIC on such a host is enslaved to the OVS uplink bridge and holds no address. The LAN address lives on `br-ex`, which `virtualIface` already demotes through the `br-` rule, while the pod-network management port `ovn-k8s-mp0` counts as physical. It becomes the only physical candidate, it qualifies, and `rankLocal` publishes it as canonical.

This names the common Kubernetes CNI interfaces virtual (OVN-Kubernetes and Open vSwitch, Geneve and VXLAN tunnel endpoints, flannel, Calico, Cilium, Antrea, kube-proxy IPVS). Both addresses then land in the overlay pass, where the existing default-route and peer-on-link evidence pick the uplink. The pod-network address is still published last rather than dropped, consistent with the existing policy that virtual is a demotion, not an exclusion.

User-visible outcome: a node running on a Kubernetes host is discoverable at its LAN address without adding it manually.

## Scope

In: `virtualIface`'s name list and its documentation, two regression tests describing the host, and the `nvpair-node-scanner` patch bump (the only binary that calls the local ranking).

Out: the container image and manifests for running a node on Kubernetes, which are a separate documentation PR; any change to the ranking's evidence tiers.

## Validation

Environment: PAIR v0.1.1 node in a pod with `hostNetwork` on a single-node OpenShift 4.22 cluster (OVN-Kubernetes), where discovery on the other nodes offered the `10.128.0.0/14` address and the node had to be added manually by its LAN address.

```
cd services/shared
go test -count=1 ./netpick/      # ok
gofmt -l ./netpick/              # clean
go vet ./netpick/                # clean
go test -count=1 ./...           # ok (all packages)
cd ../nvpair-node-scanner
go test -count=1 ./...           # ok
node scripts/spdx-headers.mjs    # 0 missing
```

With `local.go` reverted to `main`, `TestRankLocal_OVNKubernetesPublishesTheUplink` and `TestRankLocal_OVNKubernetesPeerOnLinkWinsWithoutRoute` both fail (canonical address `10.128.0.2`), and `TestVirtualIface` fails on each new name.

Go 1.26 (registry.access.redhat.com/ubi9/go-toolset), linux/arm64.

## Risk

Name matching is substring, as before. The new substrings (`ovn-`, `ovs-`, `genev`, `vxlan`, `flannel`, `cni`, `cali`, `cilium`, `antrea`, `kube`) do not appear in physical NIC names on Linux, macOS, or Windows that I am aware of. A host whose only address sits on one of these interfaces still publishes it, via the overlay pass. Only the OVN-Kubernetes case was validated on a live host; the other CNI names come from their documented interface names.

Compiled output changes for `nvpair-node-scanner` only, so it takes the PATCH bump (0.20.3 to 0.20.4); product and installer follow (0.91.7 to 0.91.8).

## Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/NVIDIA/Personal-AI-Router/blob/main/CONTRIBUTING.md).
- [x] Every commit is signed off (`git commit -s`), certifying the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] New or existing tests cover the change.
- [x] Relevant documentation is updated.
- [x] I checked the diff, changed filenames, and commit messages for credentials, private data, internal URLs, internal issue identifiers, and generated artifacts.
- [x] I recorded the validation commands and results above.
- [x] I bumped any affected component in `services/versions.json`, and described user-visible changes above so they reach the release notes.
