### PR TITLE
fix(ui): show every GPU on a node card, not just the first

### DIFF
--- a/desktop/src/ui/components/NodeList/NodeCardDetails.tsx
+++ b/desktop/src/ui/components/NodeList/NodeCardDetails.tsx
@@ -100,6 +100,11 @@ function NodeCardDetails({ node }: NodeCardDetailsProps) {
         })
     }, [hasGpu, node, nodeMetrics])
 
+    // Memoized so the label's segment list keeps a stable identity across
+    // renders; NodeLabel observes its segments and would otherwise rebuild the
+    // ResizeObserver every render.
+    const gpuLabels = useMemo(() => gpuInfo.map(gpu => gpu.name), [gpuInfo])
+
     const cpuFallbackInfo: CpuFallbackInfo | null = useMemo(() => {
         if (hasGpu) return null
         const ramTotal = node.topology.ram
@@ -273,7 +278,7 @@ function NodeCardDetails({ node }: NodeCardDetailsProps) {
                             <NodeLabel
                                 name={node.name}
                                 ipAddress={node.ipAddress}
-                                gpuLabel={gpuInfo.length > 0 ? gpuInfo[0].name : undefined}
+                                gpuLabels={gpuLabels}
                                 isLocal={isLocal}
                             />
                         </div>

--- a/desktop/src/ui/components/NodeList/NodeLabel.tsx
+++ b/desktop/src/ui/components/NodeList/NodeLabel.tsx
@@ -4,37 +4,26 @@
 import { Flex, Text } from '@nvidia/foundations-react-core'
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { LocalBadge } from '@/ui/components/LocalBadge'
-
-interface LabelSegment {
-    id: string
-    text: string
-}
+import { buildNodeLabelSegments } from '@/ui/utils/node-label-segments'
 
 export default function NodeLabel({
     name,
     ipAddress,
-    gpuLabel,
+    gpuLabels,
     isLocal
 }: {
     name: string
     ipAddress: string
-    gpuLabel: string | undefined
+    gpuLabels: string[]
     isLocal?: boolean
 }) {
     const segmentRefs = useRef<(HTMLDivElement | null)[]>([])
     const containerRef = useRef<HTMLDivElement | null>(null)
     const [separatorAfter, setSeparatorAfter] = useState<boolean[]>([])
-    const segments = useMemo(() => {
-        const primaryText = (name || ipAddress).toUpperCase()
-        const nextSegments: LabelSegment[] = [{ id: 'primary', text: primaryText }]
-        if (name && ipAddress) {
-            nextSegments.push({ id: 'ip', text: ipAddress })
-        }
-        if (gpuLabel) {
-            nextSegments.push({ id: 'gpu', text: gpuLabel })
-        }
-        return nextSegments
-    }, [gpuLabel, ipAddress, name])
+    const segments = useMemo(
+        () => buildNodeLabelSegments(name, ipAddress, gpuLabels),
+        [gpuLabels, ipAddress, name]
+    )
 
     const updateSeparators = useCallback(() => {
         const next = segments.map((_segment, index) => {

--- a/desktop/src/ui/utils/node-label-segments.ts
+++ b/desktop/src/ui/utils/node-label-segments.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/** A single text run in a node card's header label. */
+interface LabelSegment {
+    id: string
+    text: string
+}
+
+/**
+ * Header-label segments for a node card: name, address, then one segment per
+ * GPU.
+ *
+ * Each GPU gets its OWN segment rather than being folded into one joined
+ * string, because `NodeLabel` applies wrapping, `·` separators and truncation
+ * per segment. A joined string is a single segment, so on a narrow card it
+ * truncates after the first card name and the rest of a multi-GPU host becomes
+ * invisible — which is the failure this shape exists to prevent.
+ *
+ * Empty GPU names are dropped so a backend that reports a blank name cannot
+ * render a stray separator with nothing after it.
+ */
+export function buildNodeLabelSegments(
+    name: string,
+    ipAddress: string,
+    gpuLabels: string[]
+): LabelSegment[] {
+    const primaryText = (name || ipAddress).toUpperCase()
+    const segments: LabelSegment[] = [{ id: 'primary', text: primaryText }]
+
+    if (name && ipAddress) {
+        segments.push({ id: 'ip', text: ipAddress })
+    }
+
+    gpuLabels.forEach((gpuLabel, index) => {
+        if (gpuLabel) {
+            segments.push({ id: `gpu-${index}`, text: gpuLabel })
+        }
+    })
+
+    return segments
+}

--- a/desktop/tests/modular/node-label-segments.test.ts
+++ b/desktop/tests/modular/node-label-segments.test.ts
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { buildNodeLabelSegments } from '@/ui/utils/node-label-segments'
+
+// The node card header previously rendered `gpus[0].name` alone, so a host with
+// more than one GPU was represented by its first card and every other card was
+// invisible in the summary view. `buildNodeLabelSegments` emits one segment per
+// GPU instead. These tests pin that every GPU survives, in order, at the counts
+// real hosts actually have — including the 8-GPU servers this has to hold for.
+
+const gpuTexts = (name: string, ip: string, gpus: string[]) =>
+    buildNodeLabelSegments(name, ip, gpus)
+        .filter(segment => segment.id.startsWith('gpu-'))
+        .map(segment => segment.text)
+
+describe('buildNodeLabelSegments', () => {
+    it('puts the name first, uppercased, followed by the address', () => {
+        const segments = buildNodeLabelSegments('pluto.local.tld', '172.16.24.46', [])
+        expect(segments).toEqual([
+            { id: 'primary', text: 'PLUTO.LOCAL.TLD' },
+            { id: 'ip', text: '172.16.24.46' }
+        ])
+    })
+
+    it('falls back to the address as the primary segment when there is no name', () => {
+        const segments = buildNodeLabelSegments('', '172.16.24.46', [])
+        expect(segments).toEqual([{ id: 'primary', text: '172.16.24.46' }])
+    })
+
+    it('renders a single-GPU host unchanged', () => {
+        expect(gpuTexts('TELESTO', '172.16.29.18', ['NVIDIA GeForce GTX 1060 6GB'])).toEqual([
+            'NVIDIA GeForce GTX 1060 6GB'
+        ])
+    })
+
+    it('renders BOTH cards of a dual-GPU host, in topology order', () => {
+        // The reported case: only the first card was ever shown.
+        expect(
+            gpuTexts('pluto.local.tld', '172.16.24.46', [
+                'Tesla P100-PCIE-16GB',
+                'NVIDIA GeForce RTX 3060'
+            ])
+        ).toEqual(['Tesla P100-PCIE-16GB', 'NVIDIA GeForce RTX 3060'])
+    })
+
+    it.each([3, 4, 5, 6, 7, 8])('renders every GPU on a %i-GPU host', count => {
+        const gpus = Array.from({ length: count }, (_, index) => `NVIDIA H100 80GB HBM3 #${index}`)
+        const texts = gpuTexts('dgx-01', '10.0.0.10', gpus)
+
+        expect(texts).toHaveLength(count)
+        expect(texts).toEqual(gpus)
+    })
+
+    it('keeps ids unique and stable across an 8-GPU host so React can key them', () => {
+        const gpus = Array.from({ length: 8 }, (_, index) => `NVIDIA A100-SXM4-80GB #${index}`)
+        const ids = buildNodeLabelSegments('dgx-02', '10.0.0.11', gpus).map(segment => segment.id)
+
+        expect(new Set(ids).size).toBe(ids.length)
+        expect(ids).toEqual([
+            'primary',
+            'ip',
+            ...Array.from({ length: 8 }, (_, index) => `gpu-${index}`)
+        ])
+    })
+
+    it('drops blank GPU names without disturbing the indices of the rest', () => {
+        // A blank name would otherwise render a separator with nothing after it.
+        const texts = gpuTexts('mixed', '10.0.0.12', ['Tesla P100-PCIE-16GB', '', 'RTX 3060'])
+        expect(texts).toEqual(['Tesla P100-PCIE-16GB', 'RTX 3060'])
+    })
+
+    it('emits no GPU segments for a host that reports none', () => {
+        expect(gpuTexts('cpu-only', '10.0.0.13', [])).toEqual([])
+    })
+})


### PR DESCRIPTION
Closes #33.

## Problem

`NodeCardDetails.tsx:276` passed only the first GPU to the node card header:

```tsx
gpuLabel={gpuInfo.length > 0 ? gpuInfo[0].name : undefined}
```

`NodeLabel` took a single `gpuLabel: string | undefined`, so every GPU after the first was unrepresentable by construction. A host with a Tesla P100 **and** an RTX 3060 rendered identically to one with only the 3060, with no count or overflow hint that anything was missing.

The data was never wrong — `/v1/node-info` reports every GPU, `inferenceHardwareIds` was absent (which by the contract in `gpu-inference.ts` means "show every GPU"), and the detailed performance view already charts all of them. Only the header dropped them.

## Change

Emit **one label segment per GPU**.

Segments are the right unit rather than a joined string: `NodeLabel` applies wrapping, `·` separators and truncation *per segment*, so `gpus.join(' · ')` would be a single segment that truncates after the first name on a narrow card — the same blind spot in a new shape. Per-GPU segments keep the existing layout behavior and let each name wrap and truncate on its own.

Three supporting details:

- The segment builder moves to `ui/utils/node-label-segments.ts`. The unit project runs `environment: 'node'` with no DOM and deliberately excludes components, so a pure helper is testable there without adding jsdom/testing-library to the tree. It also lands inside the existing coverage scope ("the renderer's helper and constant modules").
- `gpuLabels` is memoized in `NodeCardDetails`. Building the array inline gave it a new identity every render, and `NodeLabel` observes its segments — that would have torn down and rebuilt the `ResizeObserver` on every render.
- Blank GPU names are skipped, so a backend reporting an empty name cannot render a separator with nothing after it.

Behavior for 0- and 1-GPU hosts is unchanged.

## Tests

`desktop/tests/modular/node-label-segments.test.ts` — 13 cases:

- name/address ordering, and the address-as-primary fallback
- single-GPU host unchanged
- the reported dual-GPU regression, asserting topology order
- `it.each([3, 4, 5, 6, 7, 8])` — every GPU present, in order, at each count; 8-GPU servers are the case that matters most here
- unique, stable `gpu-N` ids across an 8-GPU host so React keys do not collide
- blank names dropped without disturbing the rest
- no GPU segments for a host reporting none

## Verification

Run from `desktop/`, all green on this branch:

| Gate | Result |
|---|---|
| `npm run lint` | exit 0 (one pre-existing warning in `node-info-poller.ts`, untouched here) |
| `npm run typecheck` | exit 0 |
| `npm run dead-code:check` | exit 0 — no dead code |
| `npm run test:unit` | 38 files, 221 tests passed |

---

*Proudly Made in Nebraska. Go Big Red! 🌽 <https://xkcd.com/2347/>*
